### PR TITLE
fix ollama model init error

### DIFF
--- a/main.py
+++ b/main.py
@@ -171,7 +171,7 @@ def get_last_url_from_chat(messages):
 
 def initialize_web_scraper_chat(url=None):
     if st.session_state.selected_model.startswith("ollama:"):
-        model = OllamaModel(st.session_state.selected_model[7:])
+        model = st.session_state.selected_model
     else:
         model = st.session_state.selected_model
     


### PR DESCRIPTION
if init model to OllamaModel,  get_prompt_for_model fun  will occur a error when try to  access startswith attribute