### PR TITLE
Fix Ollama "Event loop is closed" error on subsequent requests

### DIFF
--- a/src/ollama_models.py
+++ b/src/ollama_models.py
@@ -7,25 +7,10 @@ from .utils.error_handler import ErrorMessages
 
 logger = logging.getLogger(__name__)
 
-# Session singleton for connection pooling
-_session: aiohttp.ClientSession | None = None
-
-
-async def _get_session() -> aiohttp.ClientSession:
-    """Get or create a shared aiohttp session for connection pooling."""
-    global _session
-    if _session is None or _session.closed:
-        timeout = aiohttp.ClientTimeout(total=120)
-        _session = aiohttp.ClientSession(timeout=timeout)
-    return _session
-
-
-async def close_session() -> None:
-    """Close the shared session. Call on application shutdown."""
-    global _session
-    if _session and not _session.closed:
-        await _session.close()
-        _session = None
+# A short timeout for control-plane calls (model listing) and a generous one for generation,
+# which can stream for minutes on large local models.
+_LIST_TIMEOUT = aiohttp.ClientTimeout(total=10)
+_GENERATE_TIMEOUT = aiohttp.ClientTimeout(total=600, sock_read=120)
 
 
 class OllamaModel:
@@ -34,53 +19,56 @@ class OllamaModel:
         self.base_url = os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434')
 
     async def generate(self, prompt: str, system_prompt: str = "") -> str:
+        # Streamlit calls asyncio.run() per request, so a singleton session would
+        # be bound to a closed event loop on the second call. Open a fresh session
+        # per call — there is no pool to reuse across requests anyway.
         try:
-            session = await _get_session()
-            async with session.post(
-                f"{self.base_url}/api/generate",
-                json={
-                    "model": self.model_name,
-                    "prompt": prompt,
-                    "system": system_prompt,
-                    "stream": True
-                }
-            ) as response:
-                response.raise_for_status()
+            async with aiohttp.ClientSession(timeout=_GENERATE_TIMEOUT) as session:
+                async with session.post(
+                    f"{self.base_url}/api/generate",
+                    json={
+                        "model": self.model_name,
+                        "prompt": prompt,
+                        "system": system_prompt,
+                        "stream": True
+                    }
+                ) as response:
+                    response.raise_for_status()
 
-                # Use list + join to avoid O(n²) string concatenation
-                response_parts: list[str] = []
-                async for line in response.content:
-                    if line:
-                        try:
-                            data = json.loads(line.decode('utf-8'))
-                            if 'response' in data:
-                                response_parts.append(data['response'])
-                        except json.JSONDecodeError:
-                            logger.warning(f"Error decoding JSON: {line}")
+                    response_parts: list[str] = []
+                    async for line in response.content:
+                        if line:
+                            try:
+                                data = json.loads(line.decode('utf-8'))
+                                if 'response' in data:
+                                    response_parts.append(data['response'])
+                            except json.JSONDecodeError:
+                                logger.warning(f"Error decoding JSON: {line}")
 
-                return ''.join(response_parts)
-        except aiohttp.ClientConnectorError:
-            logger.error(ErrorMessages.OLLAMA_NOT_RUNNING)
+                    return ''.join(response_parts)
+        except aiohttp.ClientConnectorError as e:
+            logger.error(f"Ollama unreachable at {self.base_url}: {e}")
             raise Exception(ErrorMessages.OLLAMA_NOT_RUNNING)
         except aiohttp.ClientResponseError as e:
             if e.status == 404:
-                logger.error(f"Model {self.model_name} not found")
+                logger.error(f"Model {self.model_name} not found at {self.base_url}")
                 raise Exception(ErrorMessages.OLLAMA_MODEL_NOT_FOUND)
-            logger.error(f"HTTP error occurred: {str(e)}")
-            raise Exception(ErrorMessages.OLLAMA_NOT_RUNNING)
+            logger.error(f"Ollama HTTP {e.status}: {e.message}")
+            raise Exception(f"Ollama HTTP {e.status}: {e.message}")
         except Exception as e:
-            logger.error(f"An error occurred: {str(e)}")
-            raise Exception(ErrorMessages.OLLAMA_NOT_RUNNING)
+            # Re-raise the actual error instead of masking it as "Ollama not running"
+            logger.exception("Ollama generate failed")
+            raise Exception(f"Ollama generate failed: {type(e).__name__}: {e}")
 
     @staticmethod
     async def list_models() -> list[str]:
         base_url = os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434')
         try:
-            session = await _get_session()
-            async with session.get(f"{base_url}/api/tags") as response:
-                response.raise_for_status()
-                models = await response.json()
-                return [model['name'] for model in models.get('models', [])]
+            async with aiohttp.ClientSession(timeout=_LIST_TIMEOUT) as session:
+                async with session.get(f"{base_url}/api/tags") as response:
+                    response.raise_for_status()
+                    models = await response.json()
+                    return [model['name'] for model in models.get('models', [])]
         except aiohttp.ClientConnectorError:
             logger.warning(ErrorMessages.OLLAMA_NOT_RUNNING)
             return []


### PR DESCRIPTION
The module held a global aiohttp.ClientSession singleton. Streamlit invokes asyncio.run() for every user action, which creates a fresh event loop and disposes of it when the call returns. The first call (e.g. "Refresh Ollama Models") bound the session's TCPConnector to that loop. On the next call, asyncio.run() created a new loop, but _get_session() still returned the cached session whose connector pointed at the now-closed loop, raising RuntimeError: Event loop is closed. The blanket `except Exception` then re-wrapped the failure as "Ollama is not running", which was misleading.

Changes:
- Drop the singleton; open a fresh ClientSession per call inside an `async with` block. Streamlit destroys the loop between requests, so cross-request pooling never actually worked.
- Split timeouts: 10 s for /api/tags (control plane) and 600 s with sock_read=120 s for /api/generate (large local models stream for minutes).
- Stop masking arbitrary exceptions as "Ollama not running"; re-raise the real error type and message, and log it with logger.exception so root causes surface in the logs.
- Surface HTTP status/message on ClientResponseError instead of collapsing every non-404 to the generic "not running" message.