### PR TITLE
Add virtual environment activation step to usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Note: Ensure that your firewall allows connections to port 11434 for Ollama.
 
 1. Fire up the Streamlit app:
    ```bash
+   source venv/bin/activate # If not yet done
    streamlit run main.py
    ```
 


### PR DESCRIPTION
Without explicitly asking to activate the virtual environment before running main.py, issues with missing dependencies and modules arise. Adding this instruction helps the user avoid these problems.