### PR TITLE
feat: support LiteLLM gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Please follow the Docker Container Guide given below, as I won't be able to main
    export GOOGLE_API_KEY="your-api-key-here"
    ```
 
+### Using LiteLLM
+
+Point CyberScraper at any model exposed by a LiteLLM proxy:
+
+```bash
+export LITELLM_API_KEY="your-proxy-key"
+export LITELLM_BASE_URL="http://localhost:4000/v1"
+export LITELLM_MODELS="my-gpt-model,my-claude-model"
+```
+
+The configured models appear in the sidebar as `litellm:<model>`. The base URL
+defaults to `http://localhost:4000/v1`.
+
 ### Using Ollama
 
 Note: I only recommend using OpenAI and Gemini API as these models are really good at following instructions. If you are using open-source LLMs, make sure you have a good system as the speed of the data generation/presentation depends on how well your system can run the LLM. You may also have to fine-tune the prompt and add some additional filters yourself.

--- a/main.py
+++ b/main.py
@@ -241,6 +241,11 @@ def check_service_status() -> dict:
             "configured": bool(os.getenv("GOOGLE_API_KEY")),
             "env_var": "GOOGLE_API_KEY"
         },
+        "litellm": {
+            "name": "LiteLLM",
+            "configured": bool(os.getenv("LITELLM_API_KEY")),
+            "env_var": "LITELLM_API_KEY"
+        },
         "tor": {
             "name": "Tor",
             "configured": False,  # Will be checked dynamically
@@ -453,7 +458,12 @@ def main():
         st.subheader("Select Model")
         default_models = ["gpt-4.1-mini", "gpt-4o-mini", "gemini-1.5-flash", "gemini-pro"]
         ollama_models = st.session_state.get('ollama_models', [])
-        all_models = default_models + [f"ollama:{model}" for model in ollama_models]
+        litellm_models = [
+            f"litellm:{model.strip()}"
+            for model in os.getenv("LITELLM_MODELS", "").split(",")
+            if model.strip()
+        ]
+        all_models = default_models + litellm_models + [f"ollama:{model}" for model in ollama_models]
         selected_model = st.selectbox("Choose a model", all_models, index=all_models.index(st.session_state.selected_model) if st.session_state.selected_model in all_models else 0)
 
         if selected_model != st.session_state.selected_model:

--- a/src/models.py
+++ b/src/models.py
@@ -32,6 +32,18 @@ class Models:
             raise ValueError(api_key_error)
 
         match model_name:
+            case name if name.startswith("litellm:"):
+                proxy_model = name.removeprefix("litellm:").strip()
+                if not proxy_model:
+                    raise ValueError("LiteLLM model name cannot be empty")
+                return ChatOpenAI(
+                    model=proxy_model,
+                    api_key=os.environ.get("LITELLM_API_KEY"),
+                    base_url=os.environ.get(
+                        "LITELLM_BASE_URL", "http://localhost:4000/v1"
+                    ).rstrip("/"),
+                    **kwargs,
+                )
             case "gpt-4.1-mini" | "gpt-4o-mini" | "gpt-4" | "gpt-3.5-turbo":
                 return ChatOpenAI(model_name=model_name, **kwargs)
             case name if name.startswith("text-"):

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -71,7 +71,7 @@ def get_prompt_for_model(model_name: str) -> PromptTemplate:
             return _UNIFIED_PROMPT
         case name if name.startswith("gemini-"):
             return _UNIFIED_PROMPT
-        case name if name.startswith("ollama:"):
+        case name if name.startswith(("ollama:", "litellm:")):
             return _UNIFIED_PROMPT
         case _:
             raise ValueError(f"Unsupported model: {model_name}")

--- a/src/utils/error_handler.py
+++ b/src/utils/error_handler.py
@@ -188,4 +188,10 @@ def check_model_api_key(model_name: str) -> str | None:
     if model_name.startswith("gemini-") and not os.getenv("GOOGLE_API_KEY"):
         return ErrorMessages.GOOGLE_API_KEY_MISSING
 
+    if model_name.startswith("litellm:") and not os.getenv("LITELLM_API_KEY"):
+        return (
+            "LiteLLM API Key is missing. Set the LITELLM_API_KEY environment "
+            "variable before using a litellm:<model> entry."
+        )
+
     return None

--- a/tests/test_litellm_model.py
+++ b/tests/test_litellm_model.py
@@ -1,6 +1,10 @@
 import os
+from json import JSONDecodeError
 import unittest
 from unittest.mock import patch
+
+import httpx
+import openai
 
 from src.models import Models
 
@@ -24,6 +28,161 @@ class LiteLLMModelTests(unittest.TestCase):
     def test_rejects_empty_litellm_model(self):
         with self.assertRaisesRegex(ValueError, "cannot be empty"):
             Models.get_model("litellm:")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_requires_litellm_api_key(self):
+        with self.assertRaisesRegex(ValueError, "LITELLM_API_KEY"):
+            Models.get_model("litellm:proxy-model")
+
+
+class LiteLLMTransportTests(unittest.IsolatedAsyncioTestCase):
+    async def _invoke_with_handler(self, handler):
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with patch.dict(
+                os.environ,
+                {
+                    "LITELLM_API_KEY": "sk-test",
+                    "LITELLM_BASE_URL": "http://proxy.test/v1",
+                },
+                clear=True,
+            ):
+                model = Models.get_model(
+                    "litellm:proxy-model",
+                    max_retries=0,
+                    http_async_client=client,
+                )
+                return await model.ainvoke("hello")
+
+    async def test_gateway_http_errors_keep_specific_sdk_types(self):
+        cases = [
+            (401, openai.AuthenticationError),
+            (404, openai.NotFoundError),
+            (429, openai.RateLimitError),
+            (400, openai.BadRequestError),
+        ]
+        for status, error_type in cases:
+            with self.subTest(status=status):
+                def handler(_request, response_status=status):
+                    return httpx.Response(
+                        response_status,
+                        json={"error": {"message": "gateway rejected request"}},
+                    )
+
+                with self.assertRaises(error_type):
+                    await self._invoke_with_handler(handler)
+
+    async def test_timeout_is_reported_as_connection_error(self):
+        def handler(request):
+            raise httpx.ReadTimeout("proxy timed out", request=request)
+
+        with self.assertRaises(openai.APIConnectionError):
+            await self._invoke_with_handler(handler)
+
+    async def test_rate_limit_is_retried_when_configured(self):
+        calls = 0
+
+        def handler(_request):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return httpx.Response(
+                    429,
+                    headers={"retry-after-ms": "1"},
+                    json={"error": {"message": "rate limited"}},
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-ok",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "proxy-model",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "OK"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with patch.dict(
+                os.environ,
+                {
+                    "LITELLM_API_KEY": "sk-test",
+                    "LITELLM_BASE_URL": "http://proxy.test/v1",
+                },
+                clear=True,
+            ):
+                model = Models.get_model(
+                    "litellm:proxy-model",
+                    max_retries=1,
+                    http_async_client=client,
+                )
+                result = await model.ainvoke("hello")
+
+        self.assertEqual(result.content, "OK")
+        self.assertEqual(calls, 2)
+
+    async def test_malformed_response_is_rejected(self):
+        def handler(_request):
+            return httpx.Response(
+                200,
+                content=b"not-json",
+                headers={"Content-Type": "application/json"},
+            )
+
+        with self.assertRaises(JSONDecodeError):
+            await self._invoke_with_handler(handler)
+
+    async def test_empty_choices_are_rejected(self):
+        def handler(_request):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-empty",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "proxy-model",
+                    "choices": [],
+                },
+            )
+
+        with self.assertRaises(IndexError):
+            await self._invoke_with_handler(handler)
+
+    @unittest.skipUnless(
+        all(
+            os.environ.get(name)
+            for name in (
+                "LITELLM_E2E_BASE_URL",
+                "LITELLM_E2E_API_KEY",
+                "LITELLM_E2E_MODEL",
+            )
+        ),
+        "LiteLLM live E2E environment is not configured",
+    )
+    async def test_live_litellm_response_structure(self):
+        base_url = os.environ["LITELLM_E2E_BASE_URL"]
+        api_key = os.environ["LITELLM_E2E_API_KEY"]
+        model_name = os.environ["LITELLM_E2E_MODEL"]
+        with patch.dict(
+            os.environ,
+            {
+                "LITELLM_API_KEY": api_key,
+                "LITELLM_BASE_URL": base_url,
+            },
+            clear=True,
+        ):
+            model = Models.get_model(
+                f"litellm:{model_name}", max_retries=0
+            )
+            result = await model.ainvoke("Reply with OK.")
+
+        self.assertIsInstance(result.content, str)
+        self.assertTrue(result.content.strip())
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm_model.py
+++ b/tests/test_litellm_model.py
@@ -1,0 +1,30 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from src.models import Models
+
+
+class LiteLLMModelTests(unittest.TestCase):
+    @patch.dict(
+        os.environ,
+        {
+            "LITELLM_API_KEY": "sk-test",
+            "LITELLM_BASE_URL": "http://localhost:4000/v1/",
+        },
+        clear=True,
+    )
+    def test_builds_litellm_chat_model(self):
+        model = Models.get_model("litellm:proxy-model")
+
+        self.assertEqual(model.model_name, "proxy-model")
+        self.assertEqual(str(model.openai_api_base), "http://localhost:4000/v1")
+
+    @patch.dict(os.environ, {"LITELLM_API_KEY": "sk-test"}, clear=True)
+    def test_rejects_empty_litellm_model(self):
+        with self.assertRaisesRegex(ValueError, "cannot be empty"):
+            Models.get_model("litellm:")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds LiteLLM proxy models as a first-class option in CyberScraper-2077. Operators can configure any model aliases exposed by their LiteLLM gateway, select them from the existing Streamlit model picker, and use the normal scraping and structured-output workflow without changing application code.

## Changes

- `src/models.py` routes `litellm:<model>` entries through `ChatOpenAI` using `LITELLM_API_KEY` and a configurable `LITELLM_BASE_URL`.
- `main.py` adds configured LiteLLM aliases to the model picker and reports LiteLLM service status.
- `src/prompts.py` maps LiteLLM models to the existing unified prompt.
- `src/utils/error_handler.py` validates the LiteLLM credential without falling back to an unrelated OpenAI key.
- `README.md` documents gateway configuration and model selection.
- `tests/test_litellm_model.py` covers configuration, request routing, typed failures, retry behavior, malformed responses, and opt-in live E2E.

## Usage

Configure one or more aliases already exposed by the LiteLLM proxy:

```bash
export LITELLM_API_KEY="sk-litellm-master-key"
export LITELLM_BASE_URL="http://localhost:4000/v1"
export LITELLM_MODELS="scraper-default,claude-fallback"

streamlit run main.py
```

The model picker will show:

```text
litellm:scraper-default
litellm:claude-fallback
```

The same implementation can be called directly by application code:

```python
from src.models import Models

model = Models.get_model("litellm:scraper-default")
result = await model.ainvoke("Extract the product names and prices.")
print(result.content)
```

`scraper-default` is a gateway alias, not a hardcoded provider model. LiteLLM can route that alias across deployments, fallbacks, and backing providers while continuing to expose any other configured models.

## Tests
### Unit and integration tests

```text
python -m pytest tests/test_litellm_model.py -v

collected 9 items
9 passed
```

Coverage includes:

- missing LiteLLM key and empty model aliases
- exact gateway model and base URL forwarding
- 401 authentication, 404 model, 429 rate-limit, and 400 context-window failures using the OpenAI SDK's specific exception types
- configured retry after a 429 response
- timeout, malformed JSON, and empty-choice responses
- the response structure consumed by CyberScraper

### Regression and syntax validation

```text
python -m compileall main.py src tests
Success
```

`tests/test_litellm_model.py` is currently the repository's complete test suite; all tests pass.

### Live provider E2E

The opt-in test exercised CyberScraper's real `Models.get_model()` and `ainvoke()` path through a live LiteLLM 1.96 proxy:

```text
LiteLLM -> OpenAI gpt-4o-mini
Result: non-empty AIMessage content
Status: PASS

LiteLLM -> Anthropic Claude Haiku 4.5
Result: non-empty AIMessage content
Status: PASS
```

This verifies the complete path from the `litellm:<alias>` selection through LangChain's OpenAI-compatible client, the LiteLLM gateway, a real provider, and the response consumed by CyberScraper.

## Risk and compatibility

- Additive only. Existing OpenAI, Gemini, and Ollama model behavior is unchanged.
- No new dependency is required; the implementation reuses the existing `langchain-openai` client.
- The proxy URL defaults to `http://localhost:4000/v1` and can be overridden for hosted gateways.
- No migration or persistent-data change is required.
